### PR TITLE
suggestions to cell_image_library.trs and arrayexpress.trs mapping

### DIFF
--- a/transformations/arrayexpress.trs
+++ b/transformations/arrayexpress.trs
@@ -3,6 +3,10 @@ transform column "$.'experiment'.'accession'.'_$'" to "dataset.ID";
 transform column "$.'experiment'.'name'.'_$'" to "dataset.title";
 transform column "$.'experiment'.'experimenttype'.'_$'" to "dataset.types";
 transform column "$.'experiment'.'description'.'text'.'_$'" to "dataset.description";
+/* SUGGESTED MODIFICATIONS -Dataset Information */
+transform column "$.'idf.txt'.'Comment[AEExperimentType]'.'_$'"  to "dataset.types";
+transform column "$.'idf.txt'.'Comment[AEExperimentType]'.'_$'"  to "dataSet.types.dataType.information";
+
 let "dataset.keywords[0]" = "functional genomics";
 
 /* Dataset distribution */
@@ -22,6 +26,11 @@ let "access.authorization"  = "none";
 let "access.authentication[0]" = "none"; 
 let "access.authentication[1]" = "simpleLogin";
 
+
+/* ADDITION Data Distribution Information */
+let "DataSet.availableAs.Distribution.conformsTo.DataStandard[].name = "MAGE-Tab";
+
+
 /* Organization Information */
 let "organization.ID" = "SCR:004727";
 let "organization.name" = "European Bioinformatics Institute";
@@ -29,7 +38,16 @@ let "organization.abbreviation" = "EBI";
 let "organization.homePage" = "http://www.ebi.ac.uk/";
 
 /* Treatment */
-transform column "$.'experiment'.'experimentdesign'.'_$'" to "treatment.name";
+//transform column "$.'experiment'.'experimentdesign'.'_$'" to "treatment.name";
+/* SUGGESTED CHANGES Treatment */
+//transform column "$.'experiment'.'experimentdesign'.'_$'" to "s";
+transform column "$.'experiment'.'experimentdesign'.'_$'".'_$'" to "Study.studyType.Annotation.value";
+transform column "$.'experiment'.'experimentdesigntermaccessionnumber'.'url'.'_$'" to "Study.studyType.Annotation.ontologyTermIRI";
+//transform column "$.'experiment'.'experimentdesign'.'_$'" to "treatment.name";
+transform column "$.'idf.txt'.'Experimental Factor Name'.'_$'" to "Treatment.name";
+transform column "$.'idf.txt'.'Experimental Factor Type'.'_$'" to "Treatment.(agent || intensity || duration)";
+transform column "$.'idf.txt'.'Experimental Factor Type Term Accession Number'.'_$'" to "Treatment.IdentifierInformation.identifier";
+transform column "$.'idf.txt'.'Experimental Factor Type Term Source REF'.'_$'" to "Treatment.IdentifierInformation.identifierSource";
 
 /* Data Acquisition Information */
 transform column "$.'experiment'.'arraydesign'.'accession'.'_$'" to "dataAcquisition.ID";

--- a/transformations/cell_image_library.trs
+++ b/transformations/cell_image_library.trs
@@ -4,6 +4,11 @@ transform column "$.'pr_nif_0000_37639_1'.'id'" to "dataset.title" apply {{ resu
 transform column "$.'pr_nif_0000_37639_1'.'imagedescription'" to "dataset.description";
 transform column "$.'pr_nif_0000_37639_1'.'parameterimaged'" to "dataset.dimensions";
 transform column "$.'pr_nif_0000_37639_1'.'itemtype'" to "dataset.types";
+/*ADDITION to Dataset Information  */
+transform column "$.'pr_nif_0000_37639_1'.'imagetype'" to "dataSet.types.dataType.information";
+transform column "$.'pr_nif_0000_37639_1'.'parametersimaged'" to "dataSet.types.dataType.information"; //in addition to dataset.dimensions
+transform column "$.'pr_nif_0000_37639_1'.'imagingmode'" to "dataSet.types.dataType.method";
+transform column "$.'pr_nif_0000_37639_1'.'processinghistory'" to "dataSet.types.dataType.information";
 
 /* Data Repository Information */
 let "dataRepository.ID" = "SCR:003510";
@@ -18,6 +23,13 @@ let "access.authorization"  = "none";
 let "access.authentication[0]" = "none";
 let "access.authentication[1]" = "registration";
 
+/* ADDITION Data Distribution Information */
+transform column "$.'pr_nif_0000_37639_1'.'imagedatadownloadoptions' to "DataSet.availableAs.Distribution.conformsTo.DataStandard[].name = apply {{
+arr=re.split("\s*,\s*",value,)
+result=arr
+}};
+
+
 /* Organization Information */
 let "organization.ID" = "SCR:010600";
 let "organization.name" = "American Society for Cell Biology";
@@ -31,17 +43,30 @@ result=arr
 }};
 
 /* Treatment */
-transform column "$.'pr_nif_0000_37639_1'.'preparation'" to "treatment.name";
-transform column "$.'pr_nif_0000_37639_1'.'visualizationmethods'" to "treatment.agent";
+//transform column "$.'pr_nif_0000_37639_1'.'preparation'" to "treatment.name";
+//transform column "$.'pr_nif_0000_37639_1'.'visualizationmethods'" to "treatment.agent";
+/*SUGGESTED_CHANGES Treatment -> SAMPLE PROCESSING*/
+transform column "$.'pr_nif_0000_37639_1'.'preparation'" to "Activity.name";
+transform column "$.'pr_nif_0000_37639_1'.'visualizationmethods'" to "Activity.fullName";
+
 
 /* Data Acquisition Information */
 transform column "$.'pr_nif_0000_37639_1'.'imagingmode'" to "dataAcquisition.name";
 
+
+
 /* Biological Entity */
-transform column "$.'pr_nif_0000_37639_1'.'celltype'" to "BiologicalEntity[].name" apply {{
+//transform column "$.'pr_nif_0000_37639_1'.'celltype'" to "BiologicalEntity[].name" apply {{
+//arr=re.split("\s*,\s*",value,)
+//result=arr
+}};
+/*SUGGESTED CHANGES Biological Entity */
+transform column "$.'pr_nif_0000_37639_1'.'celltype'" to "dataSet.isAbout.BiologicalEntity[].name" apply {{
 arr=re.split("\s*,\s*",value,)
 result=arr
 }};
+transform column "$.'pr_nif_0000_37639_1'.'celltype'" to "dataSet.isAbout.BiologicalEntity[].identifiers.identifierInformation.identifier"; 
+transform column "$.'pr_nif_0000_37639_1'.'celltype'" to "dataSet.isAbout.BiologicalEntity[].identifiers.identifierInformation.identifierSchema="GO";
 
 /* Dataq which needs to be reconciled with DATS 2.0 */
 transform column "$.'pr_nif_0000_37639_1'.'cellline'" to "cellline[].name" apply {{
@@ -60,7 +85,10 @@ result=arr
 
 /* Data import needs to be fixed */
 /*
-transform column "$.'pr_nif_0000_37639_1'.'attribution'" to "attribution";
+//transform column "$.'pr_nif_0000_37639_1'.'attribution'" to "attribution";
+/*SUGGESTED CHANGES
+transform column "$.'pr_nif_0000_37639_1'.'attribution'" to "dataSet.creators.Person.fullName"; //TODO:add regex to extract GO id.
+transform column "$.'pr_nif_0000_37639_1'.'link'" to "dataSet.creators.Person.affiliations.organization.name";
 */
 
 /* Data not included */


### PR DESCRIPTION
Following up on the email thread '[coredev] Updated list of repositories', here are 2 reviews of transformations.

essential: identify input feed to ensure traceability and help review of mappings

One recurrent issue is the mapping to DATS 'Treatment' from generic sample manipulations.
DATS:Activity should be used instead and 'DATS:Treatment' should be only reserved when 'interventions' or 'perturbations' can clearly be identified in the input feed.

Note: the current trs files have not been tests and there may be issues -> use as point of discusion
